### PR TITLE
fix: reuse transports avoid goroutine leak

### DIFF
--- a/protocol/http/request_test.go
+++ b/protocol/http/request_test.go
@@ -60,9 +60,9 @@ func getTestAppConfig() *config.AppConfig {
 	return appConfig
 }
 
-func TestRequestRecovery(t *testing.T) {
+func TestHttpsRequestRecovery(t *testing.T) {
 	time.Sleep(1 * time.Second)
-	server := runNormalBackupConfigResponse()
+	server := runNormalBackupConfigResponseWithHTTPS()
 	appConfig := getTestAppConfig()
 	appConfig.IP = server.URL
 
@@ -82,9 +82,9 @@ func TestRequestRecovery(t *testing.T) {
 	Assert(t, o, NilVal())
 }
 
-func TestHttpsRequestRecovery(t *testing.T) {
+func TestRequestRecovery(t *testing.T) {
 	time.Sleep(1 * time.Second)
-	server := runNormalBackupConfigResponseWithHTTPS()
+	server := runNormalBackupConfigResponse()
 	appConfig := getTestAppConfig()
 	appConfig.IP = server.URL
 


### PR DESCRIPTION
> https://golang.org/pkg/net/http/
> By default, Transport caches connections for future re-use. This may leave many open connections when accessing many hosts. This behavior can be managed using Transport's CloseIdleConnections method and the MaxIdleConnsPerHost and DisableKeepAlives fields.
> Transports should be reused instead of created as needed. Transports are safe for concurrent use by multiple goroutines.

1. goroutine增长速度与sync周期相对应，可看到大部分如下goroutine。

![image](https://user-images.githubusercontent.com/73829796/127829602-c154083a-a5ce-49b0-9e6c-b2d5cf86b268.png)

2. 复用Transport之后，对比如下，第2张图，goroutine数量维持稳定不再增长。 

![image](https://user-images.githubusercontent.com/73829796/127830185-21308665-5bc1-42c2-bd5c-c0443e20c5a8.png)

![image](https://user-images.githubusercontent.com/73829796/127830224-bbbc4ade-c43c-4c73-8df5-6585f4e37fc1.png)

