### PR TITLE
if namespace is yml,but sync.GetSyncURI always return json

### DIFF
--- a/component/remote/sync.go
+++ b/component/remote/sync.go
@@ -47,7 +47,7 @@ func (*syncApolloConfig) GetNotifyURLSuffix(notifications string, config config.
 }
 
 func (*syncApolloConfig) GetSyncURI(config config.AppConfig, namespaceName string) string {
-	return fmt.Sprintf("configfiles/json/%s/%s/%s?&ip=%s",
+	return fmt.Sprintf("configfiles/%s/%s/%s?ip=%s",
 		url.QueryEscape(config.AppID),
 		url.QueryEscape(config.Cluster),
 		url.QueryEscape(namespaceName),


### PR DESCRIPTION
sync.go : if namespace is yml,but sync.GetSyncURI always return json  

```
c := &config.AppConfig{
		AppID:          "test",
		Cluster:        "DEV",
		IP:             "http://1:8080",27.0.0.1:8080",
		NamespaceName:  "test.yml", //if this is properties . it will be fine.
		IsBackupConfig: true,
		Secret:         "",
	}

cache := client.GetConfigCache(c.NamespaceName)
value, _ := cache.Get("test.t")
fmt.Println(value) // empty value
```

