### PR TITLE
[Fix] 修复当调用  repository.go 中 GetXXXValue，类型不一致时的报错

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,8 +20,6 @@ package agollo
 import (
 	"container/list"
 	"errors"
-	"strconv"
-
 	"github.com/apolloconfig/agollo/v4/agcache"
 	"github.com/apolloconfig/agollo/v4/agcache/memory"
 	"github.com/apolloconfig/agollo/v4/cluster/roundrobin"
@@ -195,89 +193,37 @@ func (c *internalClient) GetApolloConfigCache() agcache.CacheInterface {
 
 //GetValue 获取配置
 func (c *internalClient) GetValue(key string) string {
-	value := c.getConfigValue(key)
-	if value == nil {
-		return utils.Empty
-	}
-
-	return value.(string)
+	return c.GetConfig(storage.GetDefaultNamespace()).GetValue(key)
 }
 
 //GetStringValue 获取string配置值
 func (c *internalClient) GetStringValue(key string, defaultValue string) string {
-	value := c.GetValue(key)
-	if value == utils.Empty {
-		return defaultValue
-	}
-
-	return value
+	return c.GetConfig(storage.GetDefaultNamespace()).GetStringValue(key, defaultValue)
 }
 
 //GetIntValue 获取int配置值
 func (c *internalClient) GetIntValue(key string, defaultValue int) int {
-	value := c.GetValue(key)
-
-	i, err := strconv.Atoi(value)
-	if err != nil {
-		log.Debug("convert to int fail!error:", err)
-		return defaultValue
-	}
-
-	return i
+	return c.GetConfig(storage.GetDefaultNamespace()).GetIntValue(key, defaultValue)
 }
 
 //GetFloatValue 获取float配置值
 func (c *internalClient) GetFloatValue(key string, defaultValue float64) float64 {
-	value := c.GetValue(key)
-
-	i, err := strconv.ParseFloat(value, 64)
-	if err != nil {
-		log.Debug("convert to float fail!error:", err)
-		return defaultValue
-	}
-
-	return i
+	return c.GetConfig(storage.GetDefaultNamespace()).GetFloatValue(key, defaultValue)
 }
 
 //GetBoolValue 获取bool 配置值
 func (c *internalClient) GetBoolValue(key string, defaultValue bool) bool {
-	value := c.GetValue(key)
-
-	b, err := strconv.ParseBool(value)
-	if err != nil {
-		log.Debug("convert to bool fail!error:", err)
-		return defaultValue
-	}
-
-	return b
+	return c.GetConfig(storage.GetDefaultNamespace()).GetBoolValue(key, defaultValue)
 }
 
 //GetStringSliceValue 获取[]string 配置值
 func (c *internalClient) GetStringSliceValue(key string, defaultValue []string) []string {
-	value := c.getConfigValue(key)
-
-	if value == nil {
-		return defaultValue
-	}
-	s, ok := value.([]string)
-	if !ok {
-		return defaultValue
-	}
-	return s
+	return c.GetConfig(storage.GetDefaultNamespace()).GetStringSliceValue(key, defaultValue)
 }
 
 //GetIntSliceValue 获取[]int 配置值
 func (c *internalClient) GetIntSliceValue(key string, defaultValue []int) []int {
-	value := c.getConfigValue(key)
-
-	if value == nil {
-		return defaultValue
-	}
-	s, ok := value.([]int)
-	if !ok {
-		return defaultValue
-	}
-	return s
+	return c.GetConfig(storage.GetDefaultNamespace()).GetIntSliceValue(key, defaultValue)
 }
 
 func (c *internalClient) getConfigValue(key string) interface{} {

--- a/client_test.go
+++ b/client_test.go
@@ -49,11 +49,11 @@ func createMockApolloConfig(expireTime int) *internalClient {
 	//string
 	configs["string"] = "value"
 	//int
-	configs["int"] = "1"
+	configs["int"] = 1
 	//float
-	configs["float"] = "190.3"
+	configs["float"] = 190.3
 	//bool
-	configs["bool"] = "true"
+	configs["bool"] = true
 	//string slice
 	configs["stringSlice"] = []string{"1", "2"}
 
@@ -159,7 +159,7 @@ func TestGetFloatValue(t *testing.T) {
 	//error type
 	v = client.GetFloatValue("int", defaultValue)
 
-	Assert(t, float64(1), Equal(v))
+	Assert(t, defaultValue, Equal(v))
 }
 
 func TestGetBoolValue(t *testing.T) {
@@ -315,7 +315,7 @@ func TestConfig_GetFloatValue(t *testing.T) {
 	//error type
 	v = config.GetFloatValue("int", defaultValue)
 
-	Assert(t, float64(1), Equal(v))
+	Assert(t, defaultValue, Equal(v))
 }
 
 func TestConfig_GetIntValue(t *testing.T) {

--- a/storage/repository.go
+++ b/storage/repository.go
@@ -21,7 +21,6 @@ import (
 	"container/list"
 	"fmt"
 	"reflect"
-	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -182,40 +181,32 @@ func (c *Config) GetSliceValue(key string) []interface{} {
 
 //GetIntValue 获取配置值（int），获取不到则取默认值
 func (c *Config) GetIntValue(key string, defaultValue int) int {
-	value := c.GetValue(key)
+	value := c.getConfigValue(key)
 
-	i, err := strconv.Atoi(value)
-	if err != nil {
-		log.Debug("convert to int fail!error:", err)
+	if value == nil {
 		return defaultValue
 	}
-	return i
+	return value.(int)
 }
 
 //GetFloatValue 获取配置值（float），获取不到则取默认值
 func (c *Config) GetFloatValue(key string, defaultValue float64) float64 {
-	value := c.GetValue(key)
+	value := c.getConfigValue(key)
 
-	i, err := strconv.ParseFloat(value, 64)
-	if err != nil {
-		log.Debug("convert to float fail!error:", err)
+	if value == nil {
 		return defaultValue
 	}
-
-	return i
+	return value.(float64)
 }
 
 //GetBoolValue 获取配置值（bool），获取不到则取默认值
 func (c *Config) GetBoolValue(key string, defaultValue bool) bool {
-	value := c.GetValue(key)
+	value := c.getConfigValue(key)
 
-	b, err := strconv.ParseBool(value)
-	if err != nil {
-		log.Debug("convert to bool fail!error:", err)
+	if value == nil {
 		return defaultValue
 	}
-
-	return b
+	return value.(bool)
 }
 
 //UpdateApolloConfig 根据config server返回的内容更新内存

--- a/storage/repository.go
+++ b/storage/repository.go
@@ -139,7 +139,12 @@ func (c *Config) GetValue(key string) string {
 		return utils.Empty
 	}
 
-	return value.(string)
+	v, ok := value.(string)
+	if !ok {
+		log.Debug("convert to string fail ! source type:%T", value)
+		return utils.Empty
+	}
+	return v
 }
 
 //GetStringValue 获取配置值（string），获取不到则取默认值
@@ -153,30 +158,45 @@ func (c *Config) GetStringValue(key string, defaultValue string) string {
 }
 
 //GetStringSliceValue 获取配置值（[]string）
-func (c *Config) GetStringSliceValue(key string) []string {
+func (c *Config) GetStringSliceValue(key string, defaultValue []string) []string {
 	value := c.getConfigValue(key)
 	if value == nil {
-		return []string{}
+		return defaultValue
 	}
-	return value.([]string)
+	v, ok := value.([]string)
+	if !ok {
+		log.Debug("convert to []string fail ! source type:%T", value)
+		return defaultValue
+	}
+	return v
 }
 
 //GetIntSliceValue 获取配置值（[]int)
-func (c *Config) GetIntSliceValue(key string) []int {
+func (c *Config) GetIntSliceValue(key string, defaultValue []int) []int {
 	value := c.getConfigValue(key)
 	if value == nil {
-		return []int{}
+		return defaultValue
 	}
-	return value.([]int)
+	v, ok := value.([]int)
+	if !ok {
+		log.Debug("convert to []int fail ! source type:%T", value)
+		return defaultValue
+	}
+	return v
 }
 
 //GetSliceValue 获取配置值（[]interface)
-func (c *Config) GetSliceValue(key string) []interface{} {
+func (c *Config) GetSliceValue(key string, defaultValue []interface{}) []interface{} {
 	value := c.getConfigValue(key)
 	if value == nil {
-		return []interface{}{}
+		return defaultValue
 	}
-	return value.([]interface{})
+	v, ok := value.([]interface{})
+	if !ok {
+		log.Debug("convert to []interface{} fail ! source type:%T", value)
+		return defaultValue
+	}
+	return v
 }
 
 //GetIntValue 获取配置值（int），获取不到则取默认值
@@ -186,7 +206,12 @@ func (c *Config) GetIntValue(key string, defaultValue int) int {
 	if value == nil {
 		return defaultValue
 	}
-	return value.(int)
+	v, ok := value.(int)
+	if !ok {
+		log.Debug("convert to int fail ! source type:%T", value)
+		return defaultValue
+	}
+	return v
 }
 
 //GetFloatValue 获取配置值（float），获取不到则取默认值
@@ -196,17 +221,25 @@ func (c *Config) GetFloatValue(key string, defaultValue float64) float64 {
 	if value == nil {
 		return defaultValue
 	}
-	return value.(float64)
+
+	v, ok := value.(float64)
+	if !ok {
+		log.Debug("convert to float64 fail ! source type:%T", value)
+		return defaultValue
+	}
+	return v
 }
 
 //GetBoolValue 获取配置值（bool），获取不到则取默认值
 func (c *Config) GetBoolValue(key string, defaultValue bool) bool {
 	value := c.getConfigValue(key)
 
-	if value == nil {
+	v, ok := value.(bool)
+	if !ok {
+		log.Debug("convert to bool fail ! source type:%T", value)
 		return defaultValue
 	}
-	return value.(bool)
+	return v
 }
 
 //UpdateApolloConfig 根据config server返回的内容更新内存

--- a/storage/repository_test.go
+++ b/storage/repository_test.go
@@ -64,9 +64,9 @@ func TestUpdateApolloConfigNull(t *testing.T) {
 
 	configurations := make(map[string]interface{})
 	configurations["string"] = "string"
-	configurations["int"] = "1"
-	configurations["float"] = "1"
-	configurations["bool"] = "true"
+	configurations["int"] = 1
+	configurations["float"] = 1.9
+	configurations["bool"] = true
 	configurations["slice"] = []int{1, 2}
 
 	apolloConfig := &config.ApolloConfig{}
@@ -98,9 +98,9 @@ func TestGetDefaultNamespace(t *testing.T) {
 func TestGetConfig(t *testing.T) {
 	configurations := make(map[string]interface{})
 	configurations["string"] = "string2"
-	configurations["int"] = "2"
-	configurations["float"] = "1"
-	configurations["bool"] = "false"
+	configurations["int"] = 2
+	configurations["float"] = 1.9
+	configurations["bool"] = false
 	configurations["sliceString"] = []string{"1", "2", "3"}
 	configurations["sliceInt"] = []int{1, 2, 3}
 	configurations["sliceInter"] = []interface{}{1, "2", 3}
@@ -123,7 +123,7 @@ func TestGetConfig(t *testing.T) {
 
 	//float
 	f := config.GetFloatValue("float", 2)
-	Assert(t, f, Equal(float64(1)))
+	Assert(t, f, Equal(1.9))
 	f = config.GetFloatValue("f", 2)
 	Assert(t, f, Equal(float64(2)))
 
@@ -134,13 +134,13 @@ func TestGetConfig(t *testing.T) {
 	b = config.GetBoolValue("b", false)
 	Assert(t, b, Equal(false))
 
-	slice := config.GetStringSliceValue("sliceString")
+	slice := config.GetStringSliceValue("sliceString", []string{})
 	Assert(t, slice, Equal([]string{"1", "2", "3"}))
 
-	sliceInt := config.GetIntSliceValue("sliceInt")
+	sliceInt := config.GetIntSliceValue("sliceInt", []int{})
 	Assert(t, sliceInt, Equal([]int{1, 2, 3}))
 
-	sliceInter := config.GetSliceValue("sliceInter")
+	sliceInter := config.GetSliceValue("sliceInter", []interface{}{})
 	Assert(t, sliceInter, Equal([]interface{}{1, "2", 3}))
 
 	//content


### PR DESCRIPTION
* Fixed #215 修复当调用  repository.go 中 GetXXXValue，类型不一致时的报错
* 聚合 `client.go` 的 `GetXXXValue` 方法到 `repository.go`