### PR TITLE
fix data race from getDefaultTransport 这个api会产生data race

### DIFF
--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -57,9 +57,12 @@ var (
 	once sync.Once
 	// defaultTransport http.Transport
 	defaultTransport *http.Transport
+	lock             sync.Mutex
 )
 
 func getDefaultTransport(insecureSkipVerify bool) *http.Transport {
+	lock.Lock()
+	defer lock.Unlock()
 	if defaultTransport == nil {
 		once.Do(func() {
 			defaultTransport = &http.Transport{

--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -57,30 +57,24 @@ var (
 	once sync.Once
 	// defaultTransport http.Transport
 	defaultTransport *http.Transport
-	lock             sync.Mutex
 )
 
 func getDefaultTransport(insecureSkipVerify bool) *http.Transport {
-	lock.Lock()
-	defer lock.Unlock()
-	if defaultTransport == nil {
-		once.Do(func() {
-			defaultTransport = &http.Transport{
-				MaxIdleConns:        defaultMaxConnsPerHost,
-				MaxIdleConnsPerHost: defaultMaxConnsPerHost,
-				DialContext: (&net.Dialer{
-					KeepAlive: defaultKeepAliveSecond,
-					Timeout:   defaultTimeoutBySecond,
-				}).DialContext,
+	once.Do(func() {
+		defaultTransport = &http.Transport{
+			MaxIdleConns:        defaultMaxConnsPerHost,
+			MaxIdleConnsPerHost: defaultMaxConnsPerHost,
+			DialContext: (&net.Dialer{
+				KeepAlive: defaultKeepAliveSecond,
+				Timeout:   defaultTimeoutBySecond,
+			}).DialContext,
+		}
+		if insecureSkipVerify {
+			defaultTransport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: insecureSkipVerify,
 			}
-			if insecureSkipVerify {
-				defaultTransport.TLSClientConfig = &tls.Config{
-					InsecureSkipVerify: insecureSkipVerify,
-				}
-			}
-		})
-	}
-
+		}
+	})
 	return defaultTransport
 }
 


### PR DESCRIPTION
我把控制台打印日志贴出来供参考：

==================
WARNING: DATA RACE
Read at 0x000006033768 by goroutine 7:
  github.com/apolloconfig/agollo/v4/protocol/http.getDefaultTransport()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/protocol/http/request.go:63 +0x31
  github.com/apolloconfig/agollo/v4/protocol/http.Request()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/protocol/http/request.go:111 +0x1e4
  github.com/apolloconfig/agollo/v4/component/serverlist.SyncServerIPList()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/component/serverlist/sync.go:90 +0x29c
  github.com/apolloconfig/agollo/v4/component/serverlist.(*SyncServerIPListComponent).Start()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/component/serverlist/sync.go:56 +0x44
  github.com/apolloconfig/agollo/v4/component.StartRefreshConfig()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/component/common.go:27 +0x37
  github.com/apolloconfig/agollo/v4/component/serverlist.InitSyncServerIPList·dwrap·1()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/component/serverlist/sync.go:45 +0x47

Previous write at 0x000006033768 by main goroutine:
  github.com/apolloconfig/agollo/v4/protocol/http.getDefaultTransport.func1()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/protocol/http/request.go:65 +0x270
  sync.(*Once).doSlow()
      /usr/local/go/src/sync/once.go:68 +0x127
  sync.(*Once).Do()
      /usr/local/go/src/sync/once.go:59 +0x46
  github.com/apolloconfig/agollo/v4/protocol/http.getDefaultTransport()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/protocol/http/request.go:64 +0x6f
  github.com/apolloconfig/agollo/v4/protocol/http.Request()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/protocol/http/request.go:111 +0x1e4
  github.com/apolloconfig/agollo/v4/protocol/http.RequestRecovery()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/protocol/http/request.go:203 +0x186
  github.com/apolloconfig/agollo/v4/component/remote.(*AbsApolloConfig).SyncWithNamespace()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/component/remote/abs.go:58 +0x4cd
  github.com/apolloconfig/agollo/v4/component/remote.(*syncApolloConfig).Sync.func1()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/component/remote/sync.go:100 +0x9c
  github.com/apolloconfig/agollo/v4/env/config.SplitNamespaces()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/env/config/config.go:116 +0x1ac
  github.com/apolloconfig/agollo/v4/component/remote.(*syncApolloConfig).Sync()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/component/remote/sync.go:99 +0x175
  github.com/apolloconfig/agollo/v4.StartWithConfig()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/client.go:124 +0x2c9
  github.com/unionj-cloud/go-doudou/framework/configmgr.LoadFromApollo()
      /Users/wubin1989/workspace/cloud/go-doudou/framework/configmgr/apollo.go:19 +0x6f
  github.com/unionj-cloud/go-doudou/framework/internal/config.init.0()
      /Users/wubin1989/workspace/cloud/go-doudou/framework/internal/config/config.go:67 +0x719

Goroutine 7 (running) created at:
  github.com/apolloconfig/agollo/v4/component/serverlist.InitSyncServerIPList()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/component/serverlist/sync.go:45 +0xcb
  github.com/apolloconfig/agollo/v4.StartWithConfig()
      /Users/wubin1989/go/pkg/mod/github.com/apolloconfig/agollo/v4@v4.1.0/client.go:121 +0x248
  github.com/unionj-cloud/go-doudou/framework/configmgr.LoadFromApollo()
      /Users/wubin1989/workspace/cloud/go-doudou/framework/configmgr/apollo.go:19 +0x6f
  github.com/unionj-cloud/go-doudou/framework/internal/config.init.0()
      /Users/wubin1989/workspace/cloud/go-doudou/framework/internal/config/config.go:67 +0x719
==================
