### PR TITLE
fix: 不跟随系统vpn代理

### DIFF
--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -18,6 +18,7 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -69,11 +70,12 @@ func getDefaultTransport(insecureSkipVerify bool) *http.Transport {
 				KeepAlive: defaultKeepAliveSecond,
 				Timeout:   defaultTimeoutBySecond,
 			}).DialContext,
-		}
-		if insecureSkipVerify {
-			defaultTransport.TLSClientConfig = &tls.Config{
-				InsecureSkipVerify: insecureSkipVerify,
-			}
+			DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				tlsConfig := &tls.Config{
+					InsecureSkipVerify: insecureSkipVerify,
+				}
+				return tls.Dial(network, addr, tlsConfig)
+			},
 		}
 	})
 	return defaultTransport

--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -62,6 +62,7 @@ var (
 func getDefaultTransport(insecureSkipVerify bool) *http.Transport {
 	once.Do(func() {
 		defaultTransport = &http.Transport{
+			Proxy:               http.ProxyFromEnvironment,
 			MaxIdleConns:        defaultMaxConnsPerHost,
 			MaxIdleConnsPerHost: defaultMaxConnsPerHost,
 			DialContext: (&net.Dialer{

--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -18,7 +18,6 @@
 package http
 
 import (
-	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -70,12 +69,11 @@ func getDefaultTransport(insecureSkipVerify bool) *http.Transport {
 				KeepAlive: defaultKeepAliveSecond,
 				Timeout:   defaultTimeoutBySecond,
 			}).DialContext,
-			DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				tlsConfig := &tls.Config{
-					InsecureSkipVerify: insecureSkipVerify,
-				}
-				return tls.Dial(network, addr, tlsConfig)
-			},
+		}
+		if insecureSkipVerify {
+			defaultTransport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: insecureSkipVerify,
+			}
 		}
 	})
 	return defaultTransport


### PR DESCRIPTION
在使用 VPN 代理时，没有跟随环境代理，并且源码中的跳过 SSL 失效，会抛出以下异常，我修改了跟随系统 Proxy 与 SSL 跳过的源码来修复这个问题

```
Connect Apollo Server Fail,url:%s,Error:%s [https://****.com/services/config?appId=****&ip=192.168.2.102 Get "https://****.com/services/config?appId=****&ip=192.168.2.102": context deadline exceeded (Client.Timeout exceeded while awaiting headers)]
```