### PR TITLE
[Fix]修复不能通过 string 和 int 格式化数组

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,6 +42,8 @@ import (
 	"github.com/apolloconfig/agollo/v4/utils/parse/yml"
 )
 
+const separator = ","
+
 func init() {
 	extension.SetCacheFactory(&memory.DefaultCacheFactory{})
 	extension.SetLoadBalance(&roundrobin.RoundRobin{})
@@ -70,7 +72,9 @@ type Client interface {
 	GetFloatValue(key string, defaultValue float64) float64
 	GetBoolValue(key string, defaultValue bool) bool
 	GetStringSliceValue(key string, defaultValue []string) []string
+	GetStringSliceValueWithSeparator(key, separator string, defaultValue []string) []string
 	GetIntSliceValue(key string, defaultValue []int) []int
+	GetIntSliceValueWithSeparator(key, separator string, defaultValue []int) []int
 	AddChangeListener(listener storage.ChangeListener)
 	RemoveChangeListener(listener storage.ChangeListener)
 	GetChangeListeners() *list.List
@@ -221,12 +225,22 @@ func (c *internalClient) GetBoolValue(key string, defaultValue bool) bool {
 
 //GetStringSliceValue 获取[]string 配置值
 func (c *internalClient) GetStringSliceValue(key string, defaultValue []string) []string {
-	return c.GetConfig(storage.GetDefaultNamespace()).GetStringSliceValue(key, defaultValue)
+	return c.GetStringSliceValueWithSeparator(key, separator, defaultValue)
+}
+
+//GetStringSliceValueWithSeparator 获取[]string 配置值
+func (c *internalClient) GetStringSliceValueWithSeparator(key, separator string, defaultValue []string) []string {
+	return c.GetConfig(storage.GetDefaultNamespace()).GetStringSliceValue(key, separator, defaultValue)
 }
 
 //GetIntSliceValue 获取[]int 配置值
 func (c *internalClient) GetIntSliceValue(key string, defaultValue []int) []int {
-	return c.GetConfig(storage.GetDefaultNamespace()).GetIntSliceValue(key, defaultValue)
+	return c.GetIntSliceValueWithSeparator(key, separator, defaultValue)
+}
+
+//GetIntSliceValueWithSeparator 获取[]int 配置值
+func (c *internalClient) GetIntSliceValueWithSeparator(key, separator string, defaultValue []int) []int {
+	return c.GetConfig(storage.GetDefaultNamespace()).GetIntSliceValue(key, separator, defaultValue)
 }
 
 func (c *internalClient) getConfigValue(key string) interface{} {

--- a/storage/repository.go
+++ b/storage/repository.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -314,7 +315,7 @@ func (c *Config) GetStringValue(key string, defaultValue string) string {
 }
 
 // GetStringSliceValue 获取配置值（[]string）
-func (c *Config) GetStringSliceValue(key string, defaultValue []string) []string {
+func (c *Config) GetStringSliceValue(key, separator string, defaultValue []string) []string {
 	value := c.getConfigValue(key, true)
 	if value == nil {
 		return defaultValue
@@ -322,14 +323,18 @@ func (c *Config) GetStringSliceValue(key string, defaultValue []string) []string
 
 	v, ok := value.([]string)
 	if !ok {
-		log.Debugf("convert to []string fail ! source type:%T", value)
-		return defaultValue
+		s, ok := value.(string)
+		if !ok {
+			log.Debugf("convert to []string fail ! source type:%T", value)
+			return defaultValue
+		}
+		return strings.Split(s, separator)
 	}
 	return v
 }
 
 // GetIntSliceValue 获取配置值（[]int)
-func (c *Config) GetIntSliceValue(key string, defaultValue []int) []int {
+func (c *Config) GetIntSliceValue(key, separator string, defaultValue []int) []int {
 	value := c.getConfigValue(key, true)
 	if value == nil {
 		return defaultValue
@@ -337,8 +342,19 @@ func (c *Config) GetIntSliceValue(key string, defaultValue []int) []int {
 
 	v, ok := value.([]int)
 	if !ok {
-		log.Debugf("convert to []int fail ! source type:%T", value)
-		return defaultValue
+		sl := c.GetStringSliceValue(key, separator, nil)
+		if sl == nil {
+			return defaultValue
+		}
+		v = make([]int, 0, len(sl))
+		for index := range sl {
+			i, err := strconv.Atoi(sl[index])
+			if err != nil {
+				log.Debugf("convert to []int fail! value:%s,  source type:%T", sl[index], sl[index])
+				return defaultValue
+			}
+			v = append(v, i)
+		}
 	}
 	return v
 }

--- a/storage/repository_test.go
+++ b/storage/repository_test.go
@@ -104,7 +104,9 @@ func TestGetConfig(t *testing.T) {
 	configurations["bool"] = false
 	configurations["string_bool"] = "false"
 	configurations["sliceString"] = []string{"1", "2", "3"}
+	configurations["sliceStringWithSeparator"] = "1,2,3"
 	configurations["sliceInt"] = []int{1, 2, 3}
+	configurations["sliceIntWithSeparator"] = "1,2,3"
 	configurations["sliceInter"] = []interface{}{1, "2", 3}
 	c := creatTestApolloConfig(configurations, "test")
 	config := c.GetConfig("test")
@@ -148,10 +150,15 @@ func TestGetConfig(t *testing.T) {
 	b = config.GetBoolValue("b", false)
 	Assert(t, b, Equal(false))
 
-	slice := config.GetStringSliceValue("sliceString", []string{})
+	slice := config.GetStringSliceValue("sliceString", ",", []string{})
+	Assert(t, slice, Equal([]string{"1", "2", "3"}))
+	slice = config.GetStringSliceValue("sliceStringWithSeparator", ",", []string{})
 	Assert(t, slice, Equal([]string{"1", "2", "3"}))
 
-	sliceInt := config.GetIntSliceValue("sliceInt", []int{})
+	sliceInt := config.GetIntSliceValue("sliceInt", ",", []int{})
+	Assert(t, sliceInt, Equal([]int{1, 2, 3}))
+
+	sliceInt = config.GetIntSliceValue("sliceIntWithSeparator", ",", []int{})
 	Assert(t, sliceInt, Equal([]int{1, 2, 3}))
 
 	sliceInter := config.GetSliceValue("sliceInter", []interface{}{})


### PR DESCRIPTION
Fix #264 
本次只是修复可以通过以下形式读取配置：
```
a=a,b,d,c
```
后续需要切换底层数据源进行支持。