### PR TITLE
配置增加ClientIP，当存在多网卡时，获取IP可能不正确的情况，客户端可以自己传入IP

### DIFF
--- a/component/remote/async.go
+++ b/component/remote/async.go
@@ -59,12 +59,16 @@ func (*asyncApolloConfig) GetNotifyURLSuffix(notifications string, config config
 }
 
 func (*asyncApolloConfig) GetSyncURI(config config.AppConfig, namespaceName string) string {
+	var ip = config.ClientIP
+	if ip == "" {
+		ip = utils.GetInternal()
+	}
 	return fmt.Sprintf("configs/%s/%s/%s?releaseKey=%s&ip=%s&label=%s",
 		url.QueryEscape(config.AppID),
 		url.QueryEscape(config.Cluster),
 		url.QueryEscape(namespaceName),
 		url.QueryEscape(config.GetCurrentApolloConfig().GetReleaseKey(namespaceName)),
-		utils.GetInternal(),
+		ip,
 		url.QueryEscape(config.Label))
 }
 

--- a/component/remote/sync.go
+++ b/component/remote/sync.go
@@ -47,11 +47,15 @@ func (*syncApolloConfig) GetNotifyURLSuffix(notifications string, config config.
 }
 
 func (*syncApolloConfig) GetSyncURI(config config.AppConfig, namespaceName string) string {
+	var ip = config.ClientIP
+	if ip == "" {
+		ip = utils.GetInternal()
+	}
 	return fmt.Sprintf("configfiles/json/%s/%s/%s?&ip=%s&label=%s",
 		url.QueryEscape(config.AppID),
 		url.QueryEscape(config.Cluster),
 		url.QueryEscape(namespaceName),
-		utils.GetInternal(),
+		ip,
 		url.QueryEscape(config.Label))
 }
 

--- a/env/config/config.go
+++ b/env/config/config.go
@@ -32,14 +32,14 @@ var (
 	comma                 = ","
 )
 
-//File 读写配置文件
+// File 读写配置文件
 type File interface {
 	Load(fileName string, unmarshal func([]byte) (interface{}, error)) (interface{}, error)
 
 	Write(content interface{}, configPath string) error
 }
 
-//AppConfig 配置文件
+// AppConfig 配置文件
 type AppConfig struct {
 	AppID             string `json:"appId"`
 	Cluster           string `json:"cluster"`
@@ -51,12 +51,14 @@ type AppConfig struct {
 	Label             string `json:"label"`
 	SyncServerTimeout int    `json:"syncServerTimeout"`
 	// MustStart 可用于控制第一次同步必须成功
-	MustStart               bool `default:"false"`
+	MustStart bool `default:"false"`
+	// 客户端上报IP，多网卡情况下，utils.GetInternal 获取的IP可能不正确
+	ClientIP                string `json:"clientIP"`
 	notificationsMap        *notificationsMap
 	currentConnApolloConfig *CurrentApolloConfig
 }
 
-//ServerInfo 服务器信息
+// ServerInfo 服务器信息
 type ServerInfo struct {
 	AppName     string `json:"appName"`
 	InstanceID  string `json:"instanceId"`
@@ -64,19 +66,19 @@ type ServerInfo struct {
 	IsDown      bool   `json:"-"`
 }
 
-//GetIsBackupConfig whether backup config after fetch config from apollo
-//false : no
-//true : yes (default)
+// GetIsBackupConfig whether backup config after fetch config from apollo
+// false : no
+// true : yes (default)
 func (a *AppConfig) GetIsBackupConfig() bool {
 	return a.IsBackupConfig
 }
 
-//GetBackupConfigPath GetBackupConfigPath
+// GetBackupConfigPath GetBackupConfigPath
 func (a *AppConfig) GetBackupConfigPath() string {
 	return a.BackupConfigPath
 }
 
-//GetHost GetHost
+// GetHost GetHost
 func (a *AppConfig) GetHost() string {
 	u, err := url.Parse(a.IP)
 	if err != nil {
@@ -108,7 +110,7 @@ func (a *AppConfig) initAllNotifications(callback func(namespace string)) {
 	}
 }
 
-//SplitNamespaces 根据namespace字符串分割后，并执行callback函数
+// SplitNamespaces 根据namespace字符串分割后，并执行callback函数
 func SplitNamespaces(namespacesStr string, callback func(namespace string)) sync.Map {
 	namespaces := sync.Map{}
 	split := strings.Split(namespacesStr, comma)
@@ -126,12 +128,16 @@ func (a *AppConfig) GetNotificationsMap() *notificationsMap {
 	return a.notificationsMap
 }
 
-//GetServicesConfigURL 获取服务器列表url
+// GetServicesConfigURL 获取服务器列表url
 func (a *AppConfig) GetServicesConfigURL() string {
+	var ip = a.ClientIP
+	if a.ClientIP == "" {
+		ip = utils.GetInternal()
+	}
 	return fmt.Sprintf("%sservices/config?appId=%s&ip=%s",
 		a.GetHost(),
 		url.QueryEscape(a.AppID),
-		utils.GetInternal())
+		ip)
 }
 
 // SetCurrentApolloConfig nolint


### PR DESCRIPTION
1.从原理上来讲，传入IP只能有一个，本机环境可能 是多IP环境，这样通过程序获取到的IP就可能不是期望的那个。觉得有必要增加ClientIP参数
2.传入参数一共修改3个文件：
env/config/config.go:56 增加配置ClientIP
env/config/config.go:133 先取ClientIP未设置时再使用utils.GetInternal
component/remote/async.go:62 先取ClientIP未设置时再使用utils.GetInternal
component/remote/sync.go:50 先取ClientIP未设置时再使用utils.GetInternal