### PR TITLE
refactor: simplify the conversion from int to time.Duration as suggested by the golang offical doc.

### DIFF
--- a/component/remote/abs.go
+++ b/component/remote/abs.go
@@ -18,7 +18,6 @@
 package remote
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/apolloconfig/agollo/v4/component/log"
@@ -47,12 +46,7 @@ func (a *AbsApolloConfig) SyncWithNamespace(namespace string, appConfigFunc func
 		IsRetry: true,
 	}
 	if appConfig.SyncServerTimeout > 0 {
-		duration, err := time.ParseDuration(strconv.Itoa(appConfig.SyncServerTimeout) + "s")
-		if err != nil {
-			log.Errorf("parse sync server timeout %s fail, error:%v", appConfig.SyncServerTimeout, err)
-			return nil
-		}
-		c.Timeout = duration
+		c.Timeout = time.Duration(appConfig.SyncServerTimeout) * time.Second
 	}
 
 	callback := a.remoteApollo.CallBack(namespace)

--- a/component/serverlist/sync.go
+++ b/component/serverlist/sync.go
@@ -19,7 +19,6 @@ package serverlist
 
 import (
 	"encoding/json"
-	"strconv"
 	"time"
 
 	"github.com/apolloconfig/agollo/v4/env/server"
@@ -66,10 +65,10 @@ func (s *SyncServerIPListComponent) Start() {
 	}
 }
 
-//SyncServerIPList sync ip list from server
-//then
-//1.update agcache
-//2.store in disk
+// SyncServerIPList sync ip list from server
+// then
+// 1.update agcache
+// 2.store in disk
 func SyncServerIPList(appConfigFunc func() config.AppConfig) (map[string]*config.ServerInfo, error) {
 	if appConfigFunc == nil {
 		panic("can not find apollo config!please confirm!")
@@ -80,12 +79,8 @@ func SyncServerIPList(appConfigFunc func() config.AppConfig) (map[string]*config
 		AppID:  appConfig.AppID,
 		Secret: appConfig.Secret,
 	}
-	if appConfigFunc().SyncServerTimeout > 0 {
-		duration, err := time.ParseDuration(strconv.Itoa(appConfigFunc().SyncServerTimeout) + "s")
-		if err != nil {
-			return nil, err
-		}
-		c.Timeout = duration
+	if appConfig.SyncServerTimeout > 0 {
+		c.Timeout = time.Duration(appConfig.SyncServerTimeout) * time.Second
 	}
 	serverMap, err := http.Request(appConfig.GetServicesConfigURL(), c, &http.CallBack{
 		SuccessCallBack: SyncServerIPListSuccessCallBack,


### PR DESCRIPTION
见 https://pkg.go.dev/time#pkg-constants

```
To convert an integer number of units to a Duration, multiply:

seconds := 10
fmt.Print(time.Duration(seconds)*time.Second) // prints 10s

```