### PR TITLE
Failfast for explicit error http request instead of retrying (#296)

### DIFF
--- a/component/remote/async_test.go
+++ b/component/remote/async_test.go
@@ -177,8 +177,7 @@ func initNotifications() *config.AppConfig {
 	return appConfig
 }
 
-// Error response
-// will hold 5s and keep response 404
+// Error response with status and body
 func runErrorResponse(status int, body []byte) *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(status)

--- a/component/remote/async_test.go
+++ b/component/remote/async_test.go
@@ -146,7 +146,7 @@ func initMockNotifyAndConfigServerWithTwoErrResponse() *httptest.Server {
 	return runMockConfigServer(handlerMap, onlynormaltworesponse)
 }
 
-//run mock config server
+// run mock config server
 func runMockConfigServer(handlerMap map[string]func(http.ResponseWriter, *http.Request),
 	notifyHandler func(http.ResponseWriter, *http.Request)) *httptest.Server {
 	appConfig := env.InitFileConfig()
@@ -177,11 +177,12 @@ func initNotifications() *config.AppConfig {
 	return appConfig
 }
 
-//Error response
-//will hold 5s and keep response 404
-func runErrorResponse() *httptest.Server {
+// Error response
+// will hold 5s and keep response 404
+func runErrorResponse(status int, body []byte) *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
 	}))
 
 	return ts
@@ -281,10 +282,26 @@ func TestGetRemoteConfig(t *testing.T) {
 }
 
 func TestErrorGetRemoteConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		errContained string
+	}{
+		{name: "500", status: http.StatusInternalServerError, errContained: "over Max Retry Still Error"},
+		{name: "404", status: http.StatusNotFound, errContained: "Connect Apollo Server Fail"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testErrorGetRemoteConfig(t, tt.status, tt.errContained)
+		})
+	}
+}
+
+func testErrorGetRemoteConfig(t *testing.T, status int, errContained string) {
 	//clear
 	initNotifications()
 	appConfig := initNotifications()
-	server1 := runErrorResponse()
+	server1 := runErrorResponse(status, nil)
 	appConfig.IP = server1.URL
 	server.SetNextTryConnTime(appConfig.GetHost(), 0)
 
@@ -303,7 +320,7 @@ func TestErrorGetRemoteConfig(t *testing.T) {
 	t.Log("remoteConfigs:", remoteConfigs)
 	t.Log("remoteConfigs size:", len(remoteConfigs))
 
-	Assert(t, "over Max Retry Still Error", Equal(err.Error()))
+	Assert(t, err.Error(), StartWith(errContained))
 }
 
 func TestCreateApolloConfigWithJson(t *testing.T) {

--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -79,7 +79,7 @@ func getDefaultTransport(insecureSkipVerify bool) *http.Transport {
 	return defaultTransport
 }
 
-//CallBack 请求回调函数
+// CallBack 请求回调函数
 type CallBack struct {
 	SuccessCallBack   func([]byte, CallBack) (interface{}, error)
 	NotModifyCallBack func() error
@@ -87,7 +87,7 @@ type CallBack struct {
 	Namespace         string
 }
 
-//Request 建立网络请求
+// Request 建立网络请求
 func Request(requestURL string, connectionConfig *env.ConnectConfig, callBack *CallBack) (interface{}, error) {
 	client := &http.Client{}
 	//如有设置自定义超时时间即使用
@@ -175,6 +175,9 @@ func Request(requestURL string, connectionConfig *env.ConnectConfig, callBack *C
 				return nil, callBack.NotModifyCallBack()
 			}
 			return nil, nil
+		case http.StatusBadRequest, http.StatusUnauthorized, http.StatusNotFound, http.StatusMethodNotAllowed:
+			log.Errorf("Connect Apollo Server Fail, url:%s, StatusCode:%d", requestURL, res.StatusCode)
+			return nil, errors.New(fmt.Sprintf("Connect Apollo Server Fail, StatusCode:%d", res.StatusCode))
 		default:
 			log.Errorf("Connect Apollo Server Fail, url:%s, StatusCode:%d", requestURL, res.StatusCode)
 			// if error then sleep
@@ -190,7 +193,7 @@ func Request(requestURL string, connectionConfig *env.ConnectConfig, callBack *C
 	return nil, err
 }
 
-//RequestRecovery 可以恢复的请求
+// RequestRecovery 可以恢复的请求
 func RequestRecovery(appConfig config.AppConfig,
 	connectConfig *env.ConnectConfig,
 	callBack *CallBack) (interface{}, error) {

--- a/protocol/http/request_server_test.go
+++ b/protocol/http/request_server_test.go
@@ -50,10 +50,10 @@ var servicesResponseStr = `[{
 
 var normalBackupConfigCount = 0
 
-//Normal response
-//First request will hold 5s and response http.StatusNotModified
-//Second request will hold 5s and response http.StatusNotModified
-//Second request will response [{"namespaceName":"application","notificationId":3}]
+// Normal response
+// First request will hold 5s and response http.StatusNotModified
+// Second request will hold 5s and response http.StatusNotModified
+// Second request will response [{"namespaceName":"application","notificationId":3}]
 func runNormalBackupConfigResponse() *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		normalBackupConfigCount++
@@ -84,12 +84,20 @@ func runNormalBackupConfigResponseWithHTTPS() *httptest.Server {
 	return ts
 }
 
-//wait long time then response
+// wait long time then response
 func runLongTimeResponse() *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(10 * time.Second)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(configResponseStr))
+	}))
+
+	return ts
+}
+
+func runStatusCodeResponse(status int) *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
 	}))
 
 	return ts


### PR DESCRIPTION
#296 

- Failfast http status code: 400, 401, 404, 405
- Error Code Description: https://www.apolloconfig.com/#/en/usage/other-language-client-user-guide?id=_16-error-code-description