### PR TITLE
Make hash function in signature settable

### DIFF
--- a/protocol/auth/sign/sign.go
+++ b/protocol/auth/sign/sign.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
+	"hash"
 	"net/url"
 	"strconv"
 	"time"
@@ -36,6 +37,17 @@ const (
 	delimiter = "\n"
 	question  = "?"
 )
+
+var (
+	h = sha1.New
+)
+
+// SetHash set hash function
+func SetHash(f func() hash.Hash) func() hash.Hash {
+	o := h
+	h = f
+	return o
+}
 
 // AuthSignature apollo 授权
 type AuthSignature struct {
@@ -63,7 +75,7 @@ func (t *AuthSignature) HTTPHeaders(url string, appID string, secret string) map
 
 func signString(stringToSign string, accessKeySecret string) string {
 	key := []byte(accessKeySecret)
-	mac := hmac.New(sha1.New, key)
+	mac := hmac.New(h, key)
 	mac.Write([]byte(stringToSign))
 	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
 }

--- a/protocol/auth/sign/sign_test.go
+++ b/protocol/auth/sign/sign_test.go
@@ -18,8 +18,10 @@
 package sign
 
 import (
-	. "github.com/tevid/gohamcrest"
+	"crypto/sha256"
 	"testing"
+
+	. "github.com/tevid/gohamcrest"
 )
 
 const (
@@ -31,6 +33,13 @@ const (
 func TestSignString(t *testing.T) {
 	s := signString(rawURL, secret)
 	Assert(t, s, Equal("mcS95GXa7CpCjIfrbxgjKr0lRu8="))
+}
+
+func TestSetHash(t *testing.T) {
+	o := SetHash(sha256.New)
+	defer func() { SetHash(o) }()
+	s := signString(rawURL, secret)
+	Assert(t, s, Equal("XeIN8X6lAoujl6i88icVreaMYlBXeDco348545DkQDY="))
 }
 
 func TestUrl2PathWithQuery(t *testing.T) {


### PR DESCRIPTION
In case apollo server using sha256 hash function as signature, the signature function can support also.