### PR TITLE
fix: If loading a certain namespace fails, only attempt to retrieve t…

### DIFF
--- a/component/remote/sync.go
+++ b/component/remote/sync.go
@@ -108,7 +108,7 @@ func (a *syncApolloConfig) Sync(appConfigFunc func() config.AppConfig) []*config
 			configs = append(configs, apolloConfig)
 			return
 		}
-		configs = append(configs, loadBackupConfig(appConfig.NamespaceName, appConfig)...)
+		configs = append(configs, loadBackupConfig(namespace, appConfig)...)
 	})
 	return configs
 }


### PR DESCRIPTION
…he corresponding namespace from the backup instead of attempting to retrieve all namespaces from the backup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the synchronization of Apollo configurations by refining argument usage in the configuration loading process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->