### PR TITLE
fix: 如果获取不到config，尝试远端同步获取一次，获取到的内容需要更新缓存

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,7 +60,7 @@ func init() {
 
 var syncApolloConfig = remote.CreateSyncApolloConfig()
 
-//Client apollo 客户端接口
+// Client apollo 客户端接口
 type Client interface {
 	GetConfig(namespace string) *storage.Config
 	GetConfigAndInit(namespace string) *storage.Config
@@ -147,12 +147,12 @@ func StartWithConfig(loadAppConfig func() (*config.AppConfig, error)) (Client, e
 	return c, nil
 }
 
-//GetConfig 根据namespace获取apollo配置
+// GetConfig 根据namespace获取apollo配置
 func (c *internalClient) GetConfig(namespace string) *storage.Config {
 	return c.GetConfigAndInit(namespace)
 }
 
-//GetConfigAndInit 根据namespace获取apollo配置
+// GetConfigAndInit 根据namespace获取apollo配置
 func (c *internalClient) GetConfigAndInit(namespace string) *storage.Config {
 	if namespace == "" {
 		return nil
@@ -165,7 +165,10 @@ func (c *internalClient) GetConfigAndInit(namespace string) *storage.Config {
 		storage.CreateNamespaceConfig(namespace)
 
 		//sync config
-		syncApolloConfig.SyncWithNamespace(namespace, c.getAppConfig)
+		apolloConfig := syncApolloConfig.SyncWithNamespace(namespace, c.getAppConfig)
+		if apolloConfig != nil {
+			c.cache.UpdateApolloConfig(apolloConfig, c.getAppConfig)
+		}
 	}
 
 	config = c.cache.GetConfig(namespace)
@@ -173,7 +176,7 @@ func (c *internalClient) GetConfigAndInit(namespace string) *storage.Config {
 	return config
 }
 
-//GetConfigCache 根据namespace获取apollo配置的缓存
+// GetConfigCache 根据namespace获取apollo配置的缓存
 func (c *internalClient) GetConfigCache(namespace string) agcache.CacheInterface {
 	config := c.GetConfigAndInit(namespace)
 	if config == nil {
@@ -183,7 +186,7 @@ func (c *internalClient) GetConfigCache(namespace string) agcache.CacheInterface
 	return config.GetCache()
 }
 
-//GetDefaultConfigCache 获取默认缓存
+// GetDefaultConfigCache 获取默认缓存
 func (c *internalClient) GetDefaultConfigCache() agcache.CacheInterface {
 	config := c.GetConfigAndInit(storage.GetDefaultNamespace())
 	if config != nil {
@@ -192,42 +195,42 @@ func (c *internalClient) GetDefaultConfigCache() agcache.CacheInterface {
 	return nil
 }
 
-//GetApolloConfigCache 获取默认namespace的apollo配置
+// GetApolloConfigCache 获取默认namespace的apollo配置
 func (c *internalClient) GetApolloConfigCache() agcache.CacheInterface {
 	return c.GetDefaultConfigCache()
 }
 
-//GetValue 获取配置
+// GetValue 获取配置
 func (c *internalClient) GetValue(key string) string {
 	return c.GetConfig(storage.GetDefaultNamespace()).GetValue(key)
 }
 
-//GetStringValue 获取string配置值
+// GetStringValue 获取string配置值
 func (c *internalClient) GetStringValue(key string, defaultValue string) string {
 	return c.GetConfig(storage.GetDefaultNamespace()).GetStringValue(key, defaultValue)
 }
 
-//GetIntValue 获取int配置值
+// GetIntValue 获取int配置值
 func (c *internalClient) GetIntValue(key string, defaultValue int) int {
 	return c.GetConfig(storage.GetDefaultNamespace()).GetIntValue(key, defaultValue)
 }
 
-//GetFloatValue 获取float配置值
+// GetFloatValue 获取float配置值
 func (c *internalClient) GetFloatValue(key string, defaultValue float64) float64 {
 	return c.GetConfig(storage.GetDefaultNamespace()).GetFloatValue(key, defaultValue)
 }
 
-//GetBoolValue 获取bool 配置值
+// GetBoolValue 获取bool 配置值
 func (c *internalClient) GetBoolValue(key string, defaultValue bool) bool {
 	return c.GetConfig(storage.GetDefaultNamespace()).GetBoolValue(key, defaultValue)
 }
 
-//GetStringSliceValue 获取[]string 配置值
+// GetStringSliceValue 获取[]string 配置值
 func (c *internalClient) GetStringSliceValue(key string, defaultValue []string) []string {
 	return c.GetConfig(storage.GetDefaultNamespace()).GetStringSliceValue(key, separator, defaultValue)
 }
 
-//GetIntSliceValue 获取[]int 配置值
+// GetIntSliceValue 获取[]int 配置值
 func (c *internalClient) GetIntSliceValue(key string, defaultValue []int) []int {
 	return c.GetConfig(storage.GetDefaultNamespace()).GetIntSliceValue(key, separator, defaultValue)
 }

--- a/client.go
+++ b/client.go
@@ -161,9 +161,6 @@ func (c *internalClient) GetConfigAndInit(namespace string) *storage.Config {
 	config := c.cache.GetConfig(namespace)
 
 	if config == nil {
-		//init cache
-		storage.CreateNamespaceConfig(namespace)
-
 		//sync config
 		apolloConfig := syncApolloConfig.SyncWithNamespace(namespace, c.getAppConfig)
 		if apolloConfig != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -375,6 +375,7 @@ func TestGetConfigAndInitValNotNil(t *testing.T) {
 	Assert(t, cf, NotNilVal())
 	// cache should be updated
 	Assert(t, client.cache.GetConfig("testNotFound"), NotNilVal())
+	Assert(t, client.cache.GetConfig("testNotFound").GetValue("testKey"), Equal("testValue"))
 }
 
 func TestGetConfigAndInitValNil(t *testing.T) {
@@ -387,4 +388,5 @@ func TestGetConfigAndInitValNil(t *testing.T) {
 	client := createMockApolloConfig(120)
 	cf := client.GetConfig("testNotFound")
 	Assert(t, cf, NilVal())
+	Assert(t, client.cache.GetConfig("testNotFound"), NilVal())
 }

--- a/client_test.go
+++ b/client_test.go
@@ -22,10 +22,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/agiledragon/gomonkey/v2"
+
 	"github.com/apolloconfig/agollo/v4/agcache/memory"
+	"github.com/apolloconfig/agollo/v4/component/remote"
 	"github.com/apolloconfig/agollo/v4/env/config"
 	"github.com/apolloconfig/agollo/v4/env/server"
 
@@ -37,7 +41,7 @@ import (
 
 const testDefaultNamespace = "application"
 
-//init param
+// init param
 func init() {
 	extension.SetCacheFactory(&memory.DefaultCacheFactory{})
 }
@@ -351,4 +355,36 @@ func TestUseEventDispatch(t *testing.T) {
 	cache.AddChangeListener(dispatch)
 	l := cache.GetChangeListeners()
 	Assert(t, l.Len(), Equal(1))
+}
+
+func TestGetConfigAndInitValNotNil(t *testing.T) {
+	var apc *remote.AbsApolloConfig
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(apc), "SyncWithNamespace", func(_ *remote.AbsApolloConfig, namespace string, appConfigFunc func() config.AppConfig) *config.ApolloConfig {
+		return &config.ApolloConfig{
+			ApolloConnConfig: config.ApolloConnConfig{
+				AppID:         "testID",
+				NamespaceName: "testNotFound",
+			},
+			Configurations: map[string]interface{}{"testKey": "testValue"},
+		}
+	})
+	defer patch.Reset()
+
+	client := createMockApolloConfig(120)
+	cf := client.GetConfig("testNotFound")
+	Assert(t, cf, NotNilVal())
+	// cache should be updated
+	Assert(t, client.cache.GetConfig("testNotFound"), NotNilVal())
+}
+
+func TestGetConfigAndInitValNil(t *testing.T) {
+	var apc *remote.AbsApolloConfig
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(apc), "SyncWithNamespace", func(_ *remote.AbsApolloConfig, namespace string, appConfigFunc func() config.AppConfig) *config.ApolloConfig {
+		return nil
+	})
+	defer patch.Reset()
+
+	client := createMockApolloConfig(120)
+	cf := client.GetConfig("testNotFound")
+	Assert(t, cf, NilVal())
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/apolloconfig/agollo/v4
 
 require (
+	github.com/agiledragon/gomonkey/v2 v2.11.0 // indirect
 	github.com/spf13/viper v1.8.1
 	github.com/tevid/gohamcrest v1.1.1
 )


### PR DESCRIPTION
在获取不到 config 配置的时候，没有将远端获取的内容更新到本地缓存，让查询变得无意义

![image](https://github.com/apolloconfig/agollo/assets/66229105/0739599f-6d61-4012-aec7-129425dd44c5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved error handling in configuration initialization.
	- Updated cache updating mechanism for better synchronization.
- **Documentation**
	- Enhanced comments for better clarity on exported functions and interfaces.
- **Style**
	- Adjusted naming conventions for more intuitive function names.
- **Tests**
	- Added new test functions utilizing `gomonkey` for mocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->