### PR TITLE
fix: 触发懒加载时，需要同步更新notify内容，更新component监听变更的ns

### DIFF
--- a/client.go
+++ b/client.go
@@ -168,8 +168,6 @@ func (c *internalClient) GetConfigAndInit(namespace string) *storage.Config {
 			c.appConfig.GetNotificationsMap().UpdateNotify(namespace, 0)
 			// update cache
 			c.cache.UpdateApolloConfig(apolloConfig, c.getAppConfig)
-			// update configComponent
-			c.configComponent.SetAppConfig(c.getAppConfig)
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -176,7 +176,15 @@ func (c *internalClient) GetConfigAndInit(namespace string) *storage.Config {
 
 func (c *internalClient) SyncAndUpdate(namespace string, apolloConfig *config.ApolloConfig) {
 	// update appConfig only if namespace does not exist yet
-	if !strings.Contains(c.appConfig.NamespaceName, namespace) {
+	namespaces := strings.Split(c.appConfig.NamespaceName, ",")
+	exists := false
+	for _, n := range namespaces {
+		if n == namespace {
+			exists = true
+			break
+		}
+	}
+	if !exists {
 		c.appConfig.NamespaceName += "," + namespace
 	}
 

--- a/client.go
+++ b/client.go
@@ -20,7 +20,6 @@ package agollo
 import (
 	"container/list"
 	"errors"
-
 	"github.com/apolloconfig/agollo/v4/agcache"
 	"github.com/apolloconfig/agollo/v4/agcache/memory"
 	"github.com/apolloconfig/agollo/v4/cluster/roundrobin"
@@ -158,19 +157,25 @@ func (c *internalClient) GetConfigAndInit(namespace string) *storage.Config {
 		return nil
 	}
 
-	config := c.cache.GetConfig(namespace)
+	cfg := c.cache.GetConfig(namespace)
 
-	if config == nil {
+	if cfg == nil {
 		//sync config
 		apolloConfig := syncApolloConfig.SyncWithNamespace(namespace, c.getAppConfig)
 		if apolloConfig != nil {
+			// update appConfig
+			c.appConfig.NamespaceName = c.appConfig.NamespaceName + config.Comma + namespace
+			c.appConfig.GetNotificationsMap().UpdateNotify(namespace, 0)
+			// update cache
 			c.cache.UpdateApolloConfig(apolloConfig, c.getAppConfig)
+			// update configComponent
+			c.configComponent.SetAppConfig(c.getAppConfig)
 		}
 	}
 
-	config = c.cache.GetConfig(namespace)
+	cfg = c.cache.GetConfig(namespace)
 
-	return config
+	return cfg
 }
 
 // GetConfigCache 根据namespace获取apollo配置的缓存

--- a/client.go
+++ b/client.go
@@ -20,6 +20,8 @@ package agollo
 import (
 	"container/list"
 	"errors"
+	"strings"
+
 	"github.com/apolloconfig/agollo/v4/agcache"
 	"github.com/apolloconfig/agollo/v4/agcache/memory"
 	"github.com/apolloconfig/agollo/v4/cluster/roundrobin"
@@ -164,7 +166,10 @@ func (c *internalClient) GetConfigAndInit(namespace string) *storage.Config {
 		apolloConfig := syncApolloConfig.SyncWithNamespace(namespace, c.getAppConfig)
 		if apolloConfig != nil {
 			// update appConfig
-			c.appConfig.NamespaceName = c.appConfig.NamespaceName + config.Comma + namespace
+			if !strings.Contains(c.appConfig.NamespaceName, namespace) {
+				c.appConfig.NamespaceName = c.appConfig.NamespaceName + config.Comma + namespace
+			}
+			// update notification
 			c.appConfig.GetNotificationsMap().UpdateNotify(namespace, 0)
 			// update cache
 			c.cache.UpdateApolloConfig(apolloConfig, c.getAppConfig)

--- a/client.go
+++ b/client.go
@@ -165,20 +165,26 @@ func (c *internalClient) GetConfigAndInit(namespace string) *storage.Config {
 		//sync config
 		apolloConfig := syncApolloConfig.SyncWithNamespace(namespace, c.getAppConfig)
 		if apolloConfig != nil {
-			// update appConfig
-			if !strings.Contains(c.appConfig.NamespaceName, namespace) {
-				c.appConfig.NamespaceName = c.appConfig.NamespaceName + config.Comma + namespace
-			}
-			// update notification
-			c.appConfig.GetNotificationsMap().UpdateNotify(namespace, 0)
-			// update cache
-			c.cache.UpdateApolloConfig(apolloConfig, c.getAppConfig)
+			c.SyncAndUpdate(namespace, apolloConfig)
 		}
 	}
 
 	cfg = c.cache.GetConfig(namespace)
 
 	return cfg
+}
+
+func (c *internalClient) SyncAndUpdate(namespace string, apolloConfig *config.ApolloConfig) {
+	// update appConfig only if namespace does not exist yet
+	if !strings.Contains(c.appConfig.NamespaceName, namespace) {
+		c.appConfig.NamespaceName += "," + namespace
+	}
+
+	// update notification
+	c.appConfig.GetNotificationsMap().UpdateNotify(namespace, 0)
+
+	// update cache
+	c.cache.UpdateApolloConfig(apolloConfig, c.getAppConfig)
 }
 
 // GetConfigCache 根据namespace获取apollo配置的缓存

--- a/client_test.go
+++ b/client_test.go
@@ -20,6 +20,7 @@ package agollo
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/apolloconfig/agollo/v4/component/notify"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -65,6 +66,7 @@ func createMockApolloConfig(expireTime int) *internalClient {
 	configs["intSlice"] = []int{1, 2}
 
 	client.cache.UpdateApolloConfigCache(configs, expireTime, storage.GetDefaultNamespace())
+	client.configComponent = &notify.ConfigComponent{}
 
 	return client
 }

--- a/client_test.go
+++ b/client_test.go
@@ -365,7 +365,7 @@ func TestGetConfigAndInitValNotNil(t *testing.T) {
 				AppID:         "testID",
 				NamespaceName: "testNotFound",
 			},
-			Configurations: map[string]interface{}{"testKey": "testValue"},
+			Configurations: map[string]interface{}{"testKey": "testUpdatedValue"},
 		}
 	})
 	defer patch.Reset()
@@ -377,9 +377,9 @@ func TestGetConfigAndInitValNotNil(t *testing.T) {
 	// appConfig notificationsMap appConfig should be updated
 	Assert(t, client.appConfig.GetNotificationsMap().GetNotify("testNotFound"), Equal(int64(0)))
 
-	// cache should be updated
+	// cache should be updated with new configuration
 	Assert(t, client.cache.GetConfig("testNotFound"), NotNilVal())
-	Assert(t, client.cache.GetConfig("testNotFound").GetValue("testKey"), Equal("testValue"))
+	Assert(t, client.cache.GetConfig("testNotFound").GetValue("testKey"), Equal("testUpdatedValue"))
 }
 
 func TestGetConfigAndInitValNil(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -20,7 +20,6 @@ package agollo
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apolloconfig/agollo/v4/component/notify"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -30,6 +29,7 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 
 	"github.com/apolloconfig/agollo/v4/agcache/memory"
+	"github.com/apolloconfig/agollo/v4/component/notify"
 	"github.com/apolloconfig/agollo/v4/component/remote"
 	"github.com/apolloconfig/agollo/v4/env/config"
 	"github.com/apolloconfig/agollo/v4/env/server"

--- a/client_test.go
+++ b/client_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 
 	"github.com/apolloconfig/agollo/v4/agcache/memory"
-	"github.com/apolloconfig/agollo/v4/component/notify"
 	"github.com/apolloconfig/agollo/v4/component/remote"
 	"github.com/apolloconfig/agollo/v4/env/config"
 	"github.com/apolloconfig/agollo/v4/env/server"
@@ -66,7 +65,6 @@ func createMockApolloConfig(expireTime int) *internalClient {
 	configs["intSlice"] = []int{1, 2}
 
 	client.cache.UpdateApolloConfigCache(configs, expireTime, storage.GetDefaultNamespace())
-	client.configComponent = &notify.ConfigComponent{}
 
 	return client
 }
@@ -375,6 +373,10 @@ func TestGetConfigAndInitValNotNil(t *testing.T) {
 	client := createMockApolloConfig(120)
 	cf := client.GetConfig("testNotFound")
 	Assert(t, cf, NotNilVal())
+
+	// appConfig notificationsMap appConfig should be updated
+	Assert(t, client.appConfig.GetNotificationsMap().GetNotify("testNotFound"), Equal(int64(0)))
+
 	// cache should be updated
 	Assert(t, client.cache.GetConfig("testNotFound"), NotNilVal())
 	Assert(t, client.cache.GetConfig("testNotFound").GetValue("testKey"), Equal("testValue"))

--- a/component/notify/componet_notify_test.go
+++ b/component/notify/componet_notify_test.go
@@ -102,3 +102,22 @@ func getTestAppConfig() *config.AppConfig {
 	appConfig.Init()
 	return appConfig
 }
+
+func TestSetAppConfig(t *testing.T) {
+	var a *config.AppConfig = getTestAppConfig()
+	mockAppConfig := func() config.AppConfig {
+		return *a
+	}
+
+	c := &ConfigComponent{}
+	c.SetAppConfig(mockAppConfig)
+
+	// appConfig should be equal
+	Assert(t, c.appConfigFunc(), Equal(*a))
+
+	// appConfig value is be replaced
+	a.AppID = "test1"
+	a.NamespaceName = a.NamespaceName + config.Comma + "abc"
+	Assert(t, c.appConfigFunc().AppID, Equal("test1"))
+	Assert(t, c.appConfigFunc().NamespaceName, Equal("application,abc"))
+}

--- a/component/notify/componet_notify_test.go
+++ b/component/notify/componet_notify_test.go
@@ -106,6 +106,7 @@ func getTestAppConfig() *config.AppConfig {
 func TestConfigComponent_SetAppConfig_UpdatesAppConfigCorrectly(t *testing.T) {
 	expectedAppConfig := getTestAppConfig()
 	c := &ConfigComponent{}
+	// set appConfigFunc
 	c.SetAppConfig(func() config.AppConfig {
 		return *expectedAppConfig
 	})

--- a/component/notify/componet_notify_test.go
+++ b/component/notify/componet_notify_test.go
@@ -103,21 +103,19 @@ func getTestAppConfig() *config.AppConfig {
 	return appConfig
 }
 
-func TestSetAppConfig(t *testing.T) {
-	var a *config.AppConfig = getTestAppConfig()
-	mockAppConfig := func() config.AppConfig {
-		return *a
-	}
-
+func TestConfigComponent_SetAppConfig_UpdatesAppConfigCorrectly(t *testing.T) {
+	expectedAppConfig := getTestAppConfig()
 	c := &ConfigComponent{}
-	c.SetAppConfig(mockAppConfig)
+	c.SetAppConfig(func() config.AppConfig {
+		return *expectedAppConfig
+	})
 
 	// appConfig should be equal
-	Assert(t, c.appConfigFunc(), Equal(*a))
+	Assert(t, c.appConfigFunc(), Equal(*expectedAppConfig))
 
 	// appConfig value is be replaced
-	a.AppID = "test1"
-	a.NamespaceName = a.NamespaceName + config.Comma + "abc"
+	expectedAppConfig.AppID = "test1"
+	expectedAppConfig.NamespaceName = expectedAppConfig.NamespaceName + config.Comma + "abc"
 	Assert(t, c.appConfigFunc().AppID, Equal("test1"))
 	Assert(t, c.appConfigFunc().NamespaceName, Equal("application,abc"))
 }

--- a/env/config/config.go
+++ b/env/config/config.go
@@ -29,17 +29,17 @@ import (
 
 var (
 	defaultNotificationID = int64(-1)
-	comma                 = ","
+	Comma                 = ","
 )
 
-//File 读写配置文件
+// File 读写配置文件
 type File interface {
 	Load(fileName string, unmarshal func([]byte) (interface{}, error)) (interface{}, error)
 
 	Write(content interface{}, configPath string) error
 }
 
-//AppConfig 配置文件
+// AppConfig 配置文件
 type AppConfig struct {
 	AppID             string `json:"appId"`
 	Cluster           string `json:"cluster"`
@@ -56,7 +56,7 @@ type AppConfig struct {
 	currentConnApolloConfig *CurrentApolloConfig
 }
 
-//ServerInfo 服务器信息
+// ServerInfo 服务器信息
 type ServerInfo struct {
 	AppName     string `json:"appName"`
 	InstanceID  string `json:"instanceId"`
@@ -64,19 +64,19 @@ type ServerInfo struct {
 	IsDown      bool   `json:"-"`
 }
 
-//GetIsBackupConfig whether backup config after fetch config from apollo
-//false : no
-//true : yes (default)
+// GetIsBackupConfig whether backup config after fetch config from apollo
+// false : no
+// true : yes (default)
 func (a *AppConfig) GetIsBackupConfig() bool {
 	return a.IsBackupConfig
 }
 
-//GetBackupConfigPath GetBackupConfigPath
+// GetBackupConfigPath GetBackupConfigPath
 func (a *AppConfig) GetBackupConfigPath() string {
 	return a.BackupConfigPath
 }
 
-//GetHost GetHost
+// GetHost GetHost
 func (a *AppConfig) GetHost() string {
 	u, err := url.Parse(a.IP)
 	if err != nil {
@@ -108,10 +108,10 @@ func (a *AppConfig) initAllNotifications(callback func(namespace string)) {
 	}
 }
 
-//SplitNamespaces 根据namespace字符串分割后，并执行callback函数
+// SplitNamespaces 根据namespace字符串分割后，并执行callback函数
 func SplitNamespaces(namespacesStr string, callback func(namespace string)) sync.Map {
 	namespaces := sync.Map{}
-	split := strings.Split(namespacesStr, comma)
+	split := strings.Split(namespacesStr, Comma)
 	for _, namespace := range split {
 		if callback != nil {
 			callback(namespace)
@@ -126,7 +126,7 @@ func (a *AppConfig) GetNotificationsMap() *notificationsMap {
 	return a.notificationsMap
 }
 
-//GetServicesConfigURL 获取服务器列表url
+// GetServicesConfigURL 获取服务器列表url
 func (a *AppConfig) GetServicesConfigURL() string {
 	return fmt.Sprintf("%sservices/config?appId=%s&ip=%s",
 		a.GetHost(),


### PR DESCRIPTION
触发懒加载时，需要同步更新notify内容，更新component监听变更的ns；因为sync也会触发component返回，所以component不需要重新 start，期间两秒的时间足够configComponent变更appconfig


component 依赖 appconfig 的内容更新
![image](https://github.com/apolloconfig/agollo/assets/66229105/33314a13-4c33-4b6b-99da-d9cdf046bdc0)
![image](https://github.com/apolloconfig/agollo/assets/66229105/139c02b8-11e0-4e7e-91a1-3f1a4395f7a8)
![image](https://github.com/apolloconfig/agollo/assets/66229105/705ee84b-3221-4eed-9e1d-a1524082eb88)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved the logic for configuration retrieval and caching in the application.
- **Tests**
	- Enhanced testing for configuration updates and notifications.
- **Refactor**
	- Code refactoring for better readability and efficiency in configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->