### PR TITLE
单测:将gomonkey替换为xgo

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -22,11 +22,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 	"time"
 
-	"github.com/agiledragon/gomonkey/v2"
+	"github.com/xhd2015/xgo/runtime/mock"
 
 	"github.com/apolloconfig/agollo/v4/agcache/memory"
 	"github.com/apolloconfig/agollo/v4/component/remote"
@@ -358,8 +357,7 @@ func TestUseEventDispatch(t *testing.T) {
 }
 
 func TestGetConfigAndInitValNotNil(t *testing.T) {
-	var apc *remote.AbsApolloConfig
-	patch := gomonkey.ApplyMethod(reflect.TypeOf(apc), "SyncWithNamespace", func(_ *remote.AbsApolloConfig, namespace string, appConfigFunc func() config.AppConfig) *config.ApolloConfig {
+	mock.Patch((*remote.AbsApolloConfig).SyncWithNamespace, func(_ *remote.AbsApolloConfig, namespace string, appConfigFunc func() config.AppConfig) *config.ApolloConfig {
 		return &config.ApolloConfig{
 			ApolloConnConfig: config.ApolloConnConfig{
 				AppID:         "testID",
@@ -368,7 +366,6 @@ func TestGetConfigAndInitValNotNil(t *testing.T) {
 			Configurations: map[string]interface{}{"testKey": "testValue"},
 		}
 	})
-	defer patch.Reset()
 
 	client := createMockApolloConfig(120)
 	cf := client.GetConfig("testNotFound")
@@ -379,11 +376,9 @@ func TestGetConfigAndInitValNotNil(t *testing.T) {
 }
 
 func TestGetConfigAndInitValNil(t *testing.T) {
-	var apc *remote.AbsApolloConfig
-	patch := gomonkey.ApplyMethod(reflect.TypeOf(apc), "SyncWithNamespace", func(_ *remote.AbsApolloConfig, namespace string, appConfigFunc func() config.AppConfig) *config.ApolloConfig {
+	mock.Patch((*remote.AbsApolloConfig).SyncWithNamespace, func(_ *remote.AbsApolloConfig, namespace string, appConfigFunc func() config.AppConfig) *config.ApolloConfig {
 		return nil
 	})
-	defer patch.Reset()
 
 	client := createMockApolloConfig(120)
 	cf := client.GetConfig("testNotFound")

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/apolloconfig/agollo/v4
 
 require (
-	github.com/agiledragon/gomonkey/v2 v2.11.0 // indirect
 	github.com/spf13/viper v1.8.1
 	github.com/tevid/gohamcrest v1.1.1
+	github.com/xhd2015/xgo/runtime v1.0.17
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tevid/gohamcrest v1.1.1 h1:ou+xSqlIw1xfGTg1uq1nif/htZ2S3EzRqLm2BP+tYU0=
 github.com/tevid/gohamcrest v1.1.1/go.mod h1:3UvtWlqm8j5JbwYZh80D/PVBt0mJ1eJiYgZMibh0H/k=
+github.com/xhd2015/xgo/runtime v1.0.17 h1:CsGcGnEcffjAaQvI4Z6KaG0IS3SrCvz+Diw7+WJzeLs=
+github.com/xhd2015/xgo/runtime v1.0.17/go.mod h1:9GBQ2SzJCzpD3T+HRN+2C0TUOGv7qIz4s0mad1xJ8Jo=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
在这个PR中, 我使用xgo替换了gomonkey。

xgo相对于gomonkey具有如下优点: 
- 不依赖asm, 纯go实现，兼容所有的OS和架构
- 并发安全，多组用例同时mock，不会相互影响
- API更加简单，不需要`defer patch.Reset()`等代码

xgo的项目地址: https://github.com/xhd2015/xgo

使用xgo进行单测的步骤:
1. 安装
```sh
# macOS and Linux (and WSL)
curl -fsSL https://github.com/xhd2015/xgo/raw/master/install.sh | bash

# windows
powershell -c "irm github.com/xhd2015/xgo/raw/master/install.ps1|iex"
```

2. 执行test
```sh
xgo test ./...
```

测试结果:
```sh
 xgo test ./...
?       github.com/apolloconfig/agollo/v4/agcache       [no test files]
?       github.com/apolloconfig/agollo/v4/cluster       [no test files]
?       github.com/apolloconfig/agollo/v4/constant      [no test files]
?       github.com/apolloconfig/agollo/v4/env/file      [no test files]
?       github.com/apolloconfig/agollo/v4/protocol/auth [no test files]
?       github.com/apolloconfig/agollo/v4/utils/parse   [no test files]
ok      github.com/apolloconfig/agollo/v4       23.068s
ok      github.com/apolloconfig/agollo/v4/agcache/memory        0.824s
ok      github.com/apolloconfig/agollo/v4/cluster/roundrobin    1.206s
ok      github.com/apolloconfig/agollo/v4/component     1.743s
ok      github.com/apolloconfig/agollo/v4/component/log 1.390s
ok      github.com/apolloconfig/agollo/v4/component/notify      2.106s
ok      github.com/apolloconfig/agollo/v4/component/remote      29.777s
ok      github.com/apolloconfig/agollo/v4/component/serverlist  2.570s
ok      github.com/apolloconfig/agollo/v4/env   3.793s
ok      github.com/apolloconfig/agollo/v4/env/config    2.712s
ok      github.com/apolloconfig/agollo/v4/env/config/json       2.413s
ok      github.com/apolloconfig/agollo/v4/env/file/json 2.229s
ok      github.com/apolloconfig/agollo/v4/env/server    2.342s
ok      github.com/apolloconfig/agollo/v4/extension     2.274s
ok      github.com/apolloconfig/agollo/v4/protocol/auth/sign    2.305s
ok      github.com/apolloconfig/agollo/v4/protocol/http 26.223s
ok      github.com/apolloconfig/agollo/v4/storage       4.719s
ok      github.com/apolloconfig/agollo/v4/utils 1.747s
ok      github.com/apolloconfig/agollo/v4/utils/parse/normal    1.769s
ok      github.com/apolloconfig/agollo/v4/utils/parse/properties        1.915s
ok      github.com/apolloconfig/agollo/v4/utils/parse/yaml      1.854s
ok      github.com/apolloconfig/agollo/v4/utils/parse/yml       1.905s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated mocking library in test files for improved testing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->