### PR TITLE
fix: 修复 component 的 stop 先于 start 的情况下，内存泄漏的问题

### DIFF
--- a/client.go
+++ b/client.go
@@ -137,9 +137,7 @@ func StartWithConfig(loadAppConfig func() (*config.AppConfig, error)) (Client, e
 	log.Debug("init notifySyncConfigServices finished")
 
 	//start long poll sync config
-	configComponent := &notify.ConfigComponent{}
-	configComponent.SetAppConfig(c.getAppConfig)
-	configComponent.SetCache(c.cache)
+	configComponent := notify.NewConfigComponent(c.getAppConfig, c.cache)
 	go component.StartRefreshConfig(configComponent)
 	c.configComponent = configComponent
 


### PR DESCRIPTION
start 为携程启动：
![image](https://github.com/apolloconfig/agollo/assets/66229105/78fb58ea-0eaa-415c-a40b-620b870e51c4)

stop 依赖于 channel 不为空：
![image](https://github.com/apolloconfig/agollo/assets/66229105/da4d5f68-f94e-432e-ba69-1842a926155a)

在 stopstop 快于 start 情况下会出现泄漏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved initialization of configuration components for better maintainability.
- **New Features**
  - Enhanced logging capabilities within configuration components.
- **Tests**
  - Added new tests to verify the stop behavior of configuration components, ensuring reliability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->