### PR TITLE
fix：初始加载失败依旧加入懒加载列表，异步检查流程优化

### DIFF
--- a/client.go
+++ b/client.go
@@ -164,9 +164,10 @@ func (c *internalClient) GetConfigAndInit(namespace string) *storage.Config {
 	if cfg == nil {
 		//sync config
 		apolloConfig := syncApolloConfig.SyncWithNamespace(namespace, c.getAppConfig)
-		if apolloConfig != nil {
-			c.SyncAndUpdate(namespace, apolloConfig)
+		if apolloConfig == nil {
+			log.Warnf("apolloConfig is nil: %s, but it's be added notification", namespace)
 		}
+		c.SyncAndUpdate(namespace, apolloConfig)
 	}
 
 	cfg = c.cache.GetConfig(namespace)
@@ -189,10 +190,12 @@ func (c *internalClient) SyncAndUpdate(namespace string, apolloConfig *config.Ap
 	}
 
 	// update notification
-	c.appConfig.GetNotificationsMap().UpdateNotify(namespace, 0)
+	c.appConfig.GetNotificationsMap().UpdateNotify(namespace, -1)
 
 	// update cache
-	c.cache.UpdateApolloConfig(apolloConfig, c.getAppConfig)
+	if apolloConfig != nil {
+		c.cache.UpdateApolloConfig(apolloConfig, c.getAppConfig)
+	}
 }
 
 // GetConfigCache 根据namespace获取apollo配置的缓存

--- a/client_test.go
+++ b/client_test.go
@@ -374,7 +374,7 @@ func TestGetConfigAndInitValNotNil(t *testing.T) {
 	Assert(t, cf, NotNilVal())
 
 	// appConfig notificationsMap appConfig should be updated
-	Assert(t, client.appConfig.GetNotificationsMap().GetNotify("testNotFound"), Equal(int64(0)))
+	Assert(t, client.appConfig.GetNotificationsMap().GetNotify("testNotFound"), Equal(int64(-1)))
 
 	// cache should be updated with new configuration
 	Assert(t, client.cache.GetConfig("testNotFound"), NotNilVal())

--- a/client_test.go
+++ b/client_test.go
@@ -412,4 +412,5 @@ func TestGetConfigAndInitValNil(t *testing.T) {
 	cf := client.GetConfig("testNotFound")
 	Assert(t, cf, NilVal())
 	Assert(t, client.cache.GetConfig("testNotFound"), NilVal())
+	Assert(t, client.appConfig.GetNotificationsMap().GetNotify("testNotFound"), Equal(int64(-1)))
 }

--- a/component/remote/async.go
+++ b/component/remote/async.go
@@ -83,7 +83,9 @@ func (a *asyncApolloConfig) Sync(appConfigFunc func() config.AppConfig) []*confi
 	//只是拉去有变化的配置, 并更新拉取成功的namespace的notify ID
 	for _, notifyConfig := range remoteConfigs {
 		apolloConfig := a.SyncWithNamespace(notifyConfig.NamespaceName, appConfigFunc)
-		if apolloConfig != nil {
+		// update valid apolloConfig
+		// if apolloConfig.Configurations are empty, async should ignore it
+		if apolloConfig != nil && len(apolloConfig.Configurations) > 0 {
 			appConfig.GetNotificationsMap().UpdateNotify(notifyConfig.NamespaceName, notifyConfig.NotificationID)
 			apolloConfigs = append(apolloConfigs, apolloConfig)
 		}

--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -213,7 +213,12 @@ func RequestRecovery(appConfig config.AppConfig,
 			return response, nil
 		}
 
-		server.SetDownNode(appConfig.GetHost(), host)
+		// can use node length > 1, should be down node
+		if server.GetServersLen(appConfig.GetHost()) > 1 {
+			server.SetDownNode(appConfig.GetHost(), host)
+		} else {
+			return nil, err
+		}
 	}
 }
 


### PR DESCRIPTION
1. 初始加载失败依旧加入懒加载列表

2. 检查到存在通知，需要判断返回的结构做没有值的容错，在异步流程中，没有值的返回是异常的，应该在请求的时候就报错了
![image](https://github.com/apolloconfig/agollo/assets/66229105/53f58267-2ace-4103-881a-74c790935921)


3. request 函数中，当只有一个节点可用的时候，直接返回，不然会造成客户端最多异常20min（等待下一次服务列表同步）
![image](https://github.com/apolloconfig/agollo/assets/66229105/d5e0babd-8431-4eac-89d1-ab451f5c819e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of `apolloConfig` being `nil` by logging a warning before proceeding with `SyncAndUpdate`.
  - Conditional logic added to prevent updates when `apolloConfig.Configurations` is empty.
  - Enhanced error handling in `RequestRecovery` by ensuring node length checks before setting nodes as down.
  - Adjusted test assertions to validate the proper handling of configuration notifications with `-1` instead of `0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->