### PR TITLE
fix: backup file has no content

### DIFF
--- a/env/config/json/json_config.go
+++ b/env/config/json/json_config.go
@@ -27,11 +27,11 @@ import (
 	"github.com/apolloconfig/agollo/v4/utils"
 )
 
-//ConfigFile json文件读写
+// ConfigFile json文件读写
 type ConfigFile struct {
 }
 
-//Load json文件读
+// Load json文件读
 func (t *ConfigFile) Load(fileName string, unmarshal func([]byte) (interface{}, error)) (interface{}, error) {
 	fs, err := ioutil.ReadFile(fileName)
 	if err != nil {
@@ -47,7 +47,7 @@ func (t *ConfigFile) Load(fileName string, unmarshal func([]byte) (interface{}, 
 	return config, nil
 }
 
-//Write json文件写
+// Write json文件写
 func (t *ConfigFile) Write(content interface{}, configPath string) error {
 	if content == nil {
 		log.Error("content is null can not write backup file")
@@ -61,4 +61,14 @@ func (t *ConfigFile) Write(content interface{}, configPath string) error {
 	defer file.Close()
 
 	return json.NewEncoder(file).Encode(content)
+}
+
+// WriteWithBackup writes the given content to a new file, then renames the new file to the original file name.
+func (t *ConfigFile) WriteWithBackup(content interface{}, configPath string) error {
+	newConfigPath := configPath + ".new"
+	err := t.Write(content, newConfigPath)
+	if err != nil {
+		return err
+	}
+	return os.Rename(newConfigPath, configPath)
 }

--- a/env/config/json/json_config_test.go
+++ b/env/config/json/json_config_test.go
@@ -169,3 +169,26 @@ func TestJSONConfigFile_Write_error(t *testing.T) {
 	Assert(t, e, NotNilVal())
 	Assert(t, file, NilVal())
 }
+
+func TestJSONConfigFile_WriteWithBackup(t *testing.T) {
+	fileName := "test.json"
+	jsonConfigFile.WriteWithBackup(`{"appId":"100004458","cluster":"default","namespaceName":"application","releaseKey":"20170430092936-dee2d58e74515ff3","configurations":{"key1":"value1","key2":"value2"}}`, fileName)
+	file, e := os.Open(fileName)
+	Assert(t, e, NilVal())
+	Assert(t, file, NotNilVal())
+	file.Close()
+	os.Remove(fileName)
+}
+
+func TestJSONConfigFile_WriteWithBackup_error(t *testing.T) {
+	fileName := "/a/a/a/a//s.k"
+	e := jsonConfigFile.WriteWithBackup(`{"appId":"100004458","cluster":"default","namespaceName":"application","releaseKey":"20170430092936-dee2d58e74515ff3","configurations":{"key1":"value1","key2":"value2"}}`, fileName)
+	file, _ := os.Open(fileName)
+	Assert(t, e, NotNilVal())
+	Assert(t, file, NilVal())
+
+	e = jsonConfigFile.Write(``, fileName)
+	file, _ = os.Open(fileName)
+	Assert(t, e, NotNilVal())
+	Assert(t, file, NilVal())
+}

--- a/env/file/json/json.go
+++ b/env/file/json/json.go
@@ -21,15 +21,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/apolloconfig/agollo/v4/env/config"
 	"os"
 	"sync"
+
+	"github.com/apolloconfig/agollo/v4/env/config"
 
 	"github.com/apolloconfig/agollo/v4/component/log"
 	jsonConfig "github.com/apolloconfig/agollo/v4/env/config/json"
 )
 
-//Suffix 默认文件保存类型
+// Suffix 默认文件保存类型
 const Suffix = ".json"
 
 var (
@@ -75,7 +76,7 @@ func (fileHandler *FileHandler) WriteConfigFile(config *config.ApolloConfig, con
 	if err != nil {
 		return err
 	}
-	return jsonFileConfig.Write(config, fileHandler.GetConfigFile(configPath, config.AppID, config.NamespaceName))
+	return jsonFileConfig.WriteWithBackup(config, fileHandler.GetConfigFile(configPath, config.AppID, config.NamespaceName))
 }
 
 // GetConfigFile get real config file
@@ -95,7 +96,7 @@ func (fileHandler *FileHandler) GetConfigFile(configDir string, appID string, na
 	return configFileMap[namespace]
 }
 
-//LoadConfigFile load config from file
+// LoadConfigFile load config from file
 func (fileHandler *FileHandler) LoadConfigFile(configDir string, appID string, namespace string) (*config.ApolloConfig, error) {
 	configFilePath := fileHandler.GetConfigFile(configDir, appID, namespace)
 	log.Infof("load config file from: %s", configFilePath)

--- a/env/file/json/raw.go
+++ b/env/file/json/raw.go
@@ -19,10 +19,11 @@ package json
 
 import (
 	"fmt"
-	"github.com/apolloconfig/agollo/v4/component/log"
-	"github.com/apolloconfig/agollo/v4/env/config"
 	"os"
 	"sync"
+
+	"github.com/apolloconfig/agollo/v4/component/log"
+	"github.com/apolloconfig/agollo/v4/env/config"
 
 	"github.com/apolloconfig/agollo/v4/env/file"
 )
@@ -32,7 +33,7 @@ var (
 	rawOnce sync.Once
 )
 
-//rawFileHandler 写入备份文件时，同时写入原始内容和namespace类型
+// rawFileHandler 写入备份文件时，同时写入原始内容和namespace类型
 type rawFileHandler struct {
 	*FileHandler
 }
@@ -59,7 +60,7 @@ func writeWithRaw(config *config.ApolloConfig, configDir string) error {
 	return nil
 }
 
-//WriteConfigFile write config to file
+// WriteConfigFile write config to file
 func (fileHandler *rawFileHandler) WriteConfigFile(config *config.ApolloConfig, configPath string) error {
 	err := fileHandler.createDir(configPath)
 	if err != nil {
@@ -70,7 +71,7 @@ func (fileHandler *rawFileHandler) WriteConfigFile(config *config.ApolloConfig, 
 	if err != nil {
 		log.Errorf("writeWithRaw fail! error:%v", err)
 	}
-	return jsonFileConfig.Write(config, fileHandler.GetConfigFile(configPath, config.AppID, config.NamespaceName))
+	return jsonFileConfig.WriteWithBackup(config, fileHandler.GetConfigFile(configPath, config.AppID, config.NamespaceName))
 }
 
 // GetRawFileHandler 获取 rawFileHandler 实例


### PR DESCRIPTION
It is found that the backup file has no content in use. The specific reason is that the file writing process stops (such as closing the process). 
Based on the above reasons, the backup file writing logic is optimized, and the configuration file content is first written to a new file, and then the new file is used to overwrite the old file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fix the issue of backup file has no content.

- **Tests**
  - Added tests for the new backup writing functionality to ensure reliable performance and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->