### PR TITLE
chore: remove deprecated API and unused action

### DIFF
--- a/env/config/json/json_config.go
+++ b/env/config/json/json_config.go
@@ -20,20 +20,19 @@ package json
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 
 	"github.com/apolloconfig/agollo/v4/component/log"
 	"github.com/apolloconfig/agollo/v4/utils"
 )
 
-//ConfigFile json文件读写
+// ConfigFile json文件读写
 type ConfigFile struct {
 }
 
-//Load json文件读
+// Load json文件读
 func (t *ConfigFile) Load(fileName string, unmarshal func([]byte) (interface{}, error)) (interface{}, error) {
-	fs, err := ioutil.ReadFile(fileName)
+	fs, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, errors.New("Fail to read config file:" + err.Error())
 	}
@@ -47,7 +46,7 @@ func (t *ConfigFile) Load(fileName string, unmarshal func([]byte) (interface{}, 
 	return config, nil
 }
 
-//Write json文件写
+// Write json文件写
 func (t *ConfigFile) Write(content interface{}, configPath string) error {
 	if content == nil {
 		log.Error("content is null can not write backup file")

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/apolloconfig/agollo/v4
 
+go 1.20
+
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/spf13/viper v1.8.1
@@ -17,10 +19,8 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
-	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/text v0.3.8 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-go 1.20

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,9 @@ golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -400,8 +401,9 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
+golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -21,10 +21,10 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
-	url2 "net/url"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -97,13 +97,13 @@ func Request(requestURL string, connectionConfig *env.ConnectConfig, callBack *C
 		client.Timeout = connectTimeout
 	}
 	var err error
-	url, err := url2.Parse(requestURL)
+	u, err := url.Parse(requestURL)
 	if err != nil {
 		log.Errorf("request Apollo Server url: %q is invalid: %v", requestURL, err)
 		return nil, err
 	}
 	var insecureSkipVerify bool
-	if strings.HasPrefix(url.Scheme, "https") {
+	if strings.HasPrefix(u.Scheme, "https") {
 		insecureSkipVerify = true
 	}
 	client.Transport = getDefaultTransport(insecureSkipVerify)
@@ -157,7 +157,7 @@ func Request(requestURL string, connectionConfig *env.ConnectConfig, callBack *C
 		switch res.StatusCode {
 		case http.StatusOK:
 			var responseBody []byte
-			responseBody, err = ioutil.ReadAll(res.Body)
+			responseBody, err = io.ReadAll(res.Body)
 			if err != nil {
 				log.Errorf("Connect Apollo Server Fail, url: %s , error: %v", requestURL, err)
 				// if error then sleep


### PR DESCRIPTION
Key changes:
- Updated version declarations across all build configurations
- Remove deprecated API `ioutil`
- Prepare for adopting modern features (e.g., generics)

BREAKING CHANGE: Development environments must upgrade to Go 1.18+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Modernized file processing and HTTP request handling to align with current standards, ensuring smoother operations.

- **Chores**
  - Raised the platform version requirement to Go 1.18 and updated dependency configurations to enhance compatibility and stability.
  - Updated workflow configuration to utilize the latest setup-go action and dynamically determine the Go version from the `go.mod` file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->