### PR TITLE
fix(http): avoid marking nodes down on client errors

### DIFF
--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -184,7 +184,7 @@ func Request(requestURL string, connectionConfig *env.ConnectConfig, callBack *C
 				return nil, callBack.NotModifyCallBack()
 			}
 			return nil, nil
-		case http.StatusBadRequest, http.StatusUnauthorized, http.StatusNotFound, http.StatusMethodNotAllowed:
+		case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusMethodNotAllowed:
 			log.Errorf("Connect Apollo Server Fail, url:%s, StatusCode:%d", requestURL, res.StatusCode)
 			return nil, &clientRequestInvalidError{statusCode: res.StatusCode}
 		default:

--- a/protocol/http/request.go
+++ b/protocol/http/request.go
@@ -83,6 +83,19 @@ type CallBack struct {
 	Namespace         string
 }
 
+type clientRequestInvalidError struct {
+	statusCode int
+}
+
+func (e *clientRequestInvalidError) Error() string {
+	return fmt.Sprintf("Connect Apollo Server Fail, StatusCode:%d", e.statusCode)
+}
+
+func isClientRequestInvalidError(err error) bool {
+	var target *clientRequestInvalidError
+	return errors.As(err, &target)
+}
+
 // Request 建立网络请求
 func Request(requestURL string, connectionConfig *env.ConnectConfig, callBack *CallBack) (interface{}, error) {
 	client := &http.Client{}
@@ -173,7 +186,7 @@ func Request(requestURL string, connectionConfig *env.ConnectConfig, callBack *C
 			return nil, nil
 		case http.StatusBadRequest, http.StatusUnauthorized, http.StatusNotFound, http.StatusMethodNotAllowed:
 			log.Errorf("Connect Apollo Server Fail, url:%s, StatusCode:%d", requestURL, res.StatusCode)
-			return nil, errors.New(fmt.Sprintf("Connect Apollo Server Fail, StatusCode:%d", res.StatusCode))
+			return nil, &clientRequestInvalidError{statusCode: res.StatusCode}
 		default:
 			log.Errorf("Connect Apollo Server Fail, url:%s, StatusCode:%d", requestURL, res.StatusCode)
 			// if error then sleep
@@ -207,6 +220,10 @@ func RequestRecovery(appConfig config.AppConfig,
 		response, err = Request(requestURL, connectConfig, callBack)
 		if err == nil {
 			return response, nil
+		}
+
+		if isClientRequestInvalidError(err) {
+			return nil, err
 		}
 
 		server.SetDownNode(appConfig.GetHost(), host)

--- a/protocol/http/request_test.go
+++ b/protocol/http/request_test.go
@@ -142,6 +142,7 @@ func TestFailFastStatusCode(t *testing.T) {
 	}{
 		{name: "400", status: http.StatusBadRequest, expectedDown: false, expectedInvalid: true, expectedDurationZero: true},
 		{name: "401", status: http.StatusUnauthorized, expectedDown: false, expectedInvalid: true, expectedDurationZero: true},
+		{name: "403", status: http.StatusForbidden, expectedDown: false, expectedInvalid: true, expectedDurationZero: true},
 		{name: "404", status: http.StatusNotFound, expectedDown: false, expectedInvalid: true, expectedDurationZero: true},
 		{name: "405", status: http.StatusMethodNotAllowed, expectedDown: false, expectedInvalid: true, expectedDurationZero: true},
 		{name: "500", status: http.StatusInternalServerError, expectedDown: true, expectedInvalid: false, expectedDurationZero: false},

--- a/protocol/http/request_test.go
+++ b/protocol/http/request_test.go
@@ -134,25 +134,35 @@ func TestFailFastStatusCode(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	tests := []struct {
-		name   string
-		status int
+		name                 string
+		status               int
+		expectedDown         bool
+		expectedInvalid      bool
+		expectedDurationZero bool
 	}{
-		{name: "400", status: http.StatusBadRequest},
-		{name: "401", status: http.StatusUnauthorized},
-		{name: "404", status: http.StatusNotFound},
-		{name: "405", status: http.StatusMethodNotAllowed},
+		{name: "400", status: http.StatusBadRequest, expectedDown: false, expectedInvalid: true, expectedDurationZero: true},
+		{name: "401", status: http.StatusUnauthorized, expectedDown: false, expectedInvalid: true, expectedDurationZero: true},
+		{name: "404", status: http.StatusNotFound, expectedDown: false, expectedInvalid: true, expectedDurationZero: true},
+		{name: "405", status: http.StatusMethodNotAllowed, expectedDown: false, expectedInvalid: true, expectedDurationZero: true},
+		{name: "500", status: http.StatusInternalServerError, expectedDown: true, expectedInvalid: false, expectedDurationZero: false},
+		{name: "502", status: http.StatusBadGateway, expectedDown: true, expectedInvalid: false, expectedDurationZero: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testFailFastStatusCode(t, tt.status)
+			testFailFastStatusCode(t, tt.status, tt.expectedDown, tt.expectedInvalid, tt.expectedDurationZero)
 		})
 	}
 }
 
-func testFailFastStatusCode(t *testing.T, status int) {
-	server := runStatusCodeResponse(status)
+func testFailFastStatusCode(t *testing.T, status int, expectedDown bool, expectedInvalid bool, expectedDurationZero bool) {
+	httpServer := runStatusCodeResponse(status)
 	appConfig := getTestAppConfig()
-	appConfig.IP = server.URL
+	appConfig.IP = httpServer.URL
+	server.SetServers(appConfig.GetHost(), map[string]*config.ServerInfo{
+		appConfig.GetHost(): {
+			HomepageURL: appConfig.GetHost(),
+		},
+	})
 
 	startTime := time.Now().Unix()
 	_, err := RequestRecovery(*appConfig, &env.ConnectConfig{
@@ -164,7 +174,15 @@ func testFailFastStatusCode(t *testing.T, status int) {
 	duration := time.Now().Unix() - startTime
 
 	Assert(t, err, NotNilVal())
-	Assert(t, int64(0), Equal(duration))
+	Assert(t, isClientRequestInvalidError(err), Equal(expectedInvalid))
+	if expectedDurationZero {
+		Assert(t, int64(0), Equal(duration))
+	} else {
+		Assert(t, int64(10), Equal(duration))
+	}
+	info := server.GetServers(appConfig.GetHost())[appConfig.GetHost()]
+	Assert(t, info, NotNilVal())
+	Assert(t, info.IsDown, Equal(expectedDown))
 }
 
 func mockIPList(t *testing.T, appConfigFunc func() config.AppConfig) {


### PR DESCRIPTION
 ### Summary

  - 将 4xx 响应包装为 clientRequestInvalidError
  - RequestRecovery() 遇到这类错误时不再调用 SetDownNode
  - 保留 5xx、超时、网络错误的原有降级和下线逻辑

  ### Why

  - 之前 404 等 4xx 会被当成节点故障处理，导致单个 namespace 的请求失败污染整台节点状态
  - 这会影响后续对其他 namespace 的拉取，出现空配置且无任何提示（如启动apollo后后续通过GetConfig(namespace string) *storage.Config，如果先获取不存在的namespace，获取其他已经存在的namespace仍然会获取到nil config，且无法感知）



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of client-side HTTP errors (400, 401, 403, 404, 405) by more accurately classifying invalid requests and preventing targets from being incorrectly marked unavailable.
* **Tests**
  * Expanded and table-driven coverage for HTTP fail-fast behavior across multiple status codes, including expected error classification, timing, and whether the target is marked down.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->